### PR TITLE
ENH - make ``fit_intercept`` as parameter and pass in ``reg*lmbd_max`` to solvers

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -15,7 +15,7 @@ class Objective(BaseObjective):
     name = "L1-regularized Quantile Regression"
 
     parameters = {
-        'reg': [0.05, .1, .5],
+        'reg': [.5, .1, .05],
         'quantile': [0.2, 0.5, 0.8],
         'fit_intercept': [True, False]
     }

--- a/objective.py
+++ b/objective.py
@@ -32,7 +32,7 @@ class Objective(BaseObjective):
     def compute(self, params):
         n_features = self.X.shape[1]
         beta = params[:n_features]
-        intercept = params[0] if self.fit_intercept else 0.
+        intercept = params[-1] if self.fit_intercept else 0.
 
         y_pred = self.X.dot(beta) + intercept
         l1 = np.sum(np.abs(beta))
@@ -47,13 +47,13 @@ class Objective(BaseObjective):
         #   for all g in subdiff pinball(y), g must be in subdiff ||.||_1(0)
         # hint: consider max(x, 0) = (x + |x|) / 2 to compute subdiff pinball
         subdiff_zero = np.sign(y)/2 + (self.quantile - 1/2)
-        lmbd_max = norm(X.T @ subdiff_zero, ord=np.inf)
+        lmbd_max = norm(X.T @ subdiff_zero, ord=np.inf) / len(y)
 
         # intercept is equivalent to adding a column of ones in X
         if self.fit_intercept:
             lmbd_max = max(
                 lmbd_max,
-                np.sum(subdiff_zero)
+                np.mean(subdiff_zero)
             )
 
         return lmbd_max

--- a/objective.py
+++ b/objective.py
@@ -27,8 +27,10 @@ class Objective(BaseObjective):
         self.X, self.y = X, y
 
     def compute(self, params):
-        intercept = params[0]
-        beta = params[1:]
+        n_features = self.X.shape[1]
+        beta = params[:n_features]
+        intercept = params[0] if self.fit_intercept else 0.
+
         y_pred = self.X.dot(beta) + intercept
         l1 = np.sum(np.abs(beta))
         return pin_ball_loss(self.y, y_pred, self.quantile) + self.reg * l1
@@ -40,7 +42,7 @@ class Objective(BaseObjective):
         # optimality condition for w = 0.
         #   for all g in subdiff pinball(y), g must be in subdiff ||.||_1(0)
         # hint: consider max(x, 0) = (x + |x|) / 2 to compute subdiff pinball
-        subdiff_zero = np.sign(y)/2 + (self.quantile - 0.5)
+        subdiff_zero = np.sign(y)/2 + (self.quantile - 1/2)
         lmbd_max = norm(X.T @ subdiff_zero, ord=np.inf)
 
         # intercept is equivalent to adding a column of ones in X

--- a/objective.py
+++ b/objective.py
@@ -39,7 +39,8 @@ class Objective(BaseObjective):
         return pin_ball_loss(self.y, y_pred, self.quantile) + self.lmbd * l1
 
     def get_objective(self):
-        return dict(X=self.X, y=self.y, lmbd=self.lmbd, quantile=self.quantile)
+        return dict(X=self.X, y=self.y, lmbd=self.lmbd, quantile=self.quantile,
+                    fit_intercept=self.fit_intercept)
 
     def _get_lambda_max(self, X, y):
         # optimality condition for w = 0.

--- a/objective.py
+++ b/objective.py
@@ -16,15 +16,18 @@ class Objective(BaseObjective):
 
     parameters = {
         'reg': [0.05, .1, .5],
-        'quantile': [0.2, 0.5, 0.8]
+        'quantile': [0.2, 0.5, 0.8],
+        'fit_intercept': [True, False]
     }
 
-    def __init__(self, reg=0., quantile=0.5):
+    def __init__(self, reg=0., quantile=0.5, fit_intercept=True):
         self.reg = reg
         self.quantile = quantile
+        self.fit_intercept = fit_intercept
 
     def set_data(self, X, y):
         self.X, self.y = X, y
+        self.lmbd = self.reg * self._get_lambda_max(X, y)
 
     def compute(self, params):
         n_features = self.X.shape[1]
@@ -33,10 +36,10 @@ class Objective(BaseObjective):
 
         y_pred = self.X.dot(beta) + intercept
         l1 = np.sum(np.abs(beta))
-        return pin_ball_loss(self.y, y_pred, self.quantile) + self.reg * l1
+        return pin_ball_loss(self.y, y_pred, self.quantile) + self.lmbd * l1
 
     def get_objective(self):
-        return dict(X=self.X, y=self.y, reg=self.reg, quantile=self.quantile)
+        return dict(X=self.X, y=self.y, lmbd=self.lmbd, quantile=self.quantile)
 
     def _get_lambda_max(self, X, y):
         # optimality condition for w = 0.

--- a/solvers/scipy-linprog.py
+++ b/solvers/scipy-linprog.py
@@ -95,14 +95,15 @@ class Solver(BaseSolver):
     }
     stop_strategy = 'tolerance'
 
-    def set_objective(self, X, y, lmbd, quantile):
+    def set_objective(self, X, y, lmbd, quantile, fit_intercept):
         self.X, self.y, self.lmbd, self.quantile = X, y, lmbd, quantile
+        self.fit_intercept = fit_intercept
 
     def run(self, tol):
         tol = 1e-3 * tol
         self.coef_, self.intercept_ = quantile_regression(
             self.X, self.y, self.quantile, self.lmbd, tol,
-            self.solver, fit_intercept=True
+            self.solver, fit_intercept=self.fit_intercept
         )
 
     def get_result(self):

--- a/solvers/scipy-linprog.py
+++ b/solvers/scipy-linprog.py
@@ -9,7 +9,7 @@ with safe_import_context() as import_ctx:
     from scipy.linalg import LinAlgWarning
 
 
-def quantile_regression(X, y, quantile, reg, tol, solver, fit_intercept=True):
+def quantile_regression(X, y, quantile, lmbd, tol, solver, fit_intercept=True):
     n_samples, n_features = X.shape
     sample_weights = np.ones(n_samples) / n_samples
     n_params = n_features
@@ -22,7 +22,7 @@ def quantile_regression(X, y, quantile, reg, tol, solver, fit_intercept=True):
     # The objective is defined as 1/n * sum(pinball loss) + alpha * L1.
     # So we rescale the penalty term, which is equivalent.
     c = np.concatenate([
-        np.ones(n_params * 2) * reg,
+        np.ones(n_params * 2) * lmbd,
         sample_weights * quantile,
         sample_weights * (1 - quantile),
     ])
@@ -95,13 +95,13 @@ class Solver(BaseSolver):
     }
     stop_strategy = 'tolerance'
 
-    def set_objective(self, X, y, reg, quantile):
-        self.X, self.y, self.reg, self.quantile = X, y, reg, quantile
+    def set_objective(self, X, y, lmbd, quantile):
+        self.X, self.y, self.lmbd, self.quantile = X, y, lmbd, quantile
 
     def run(self, tol):
         tol = 1e-3 * tol
         self.coef_, self.intercept_ = quantile_regression(
-            self.X, self.y, self.quantile, self.reg, tol,
+            self.X, self.y, self.quantile, self.lmbd, tol,
             self.solver, fit_intercept=True
         )
 

--- a/solvers/scipy-linprog.py
+++ b/solvers/scipy-linprog.py
@@ -106,5 +106,5 @@ class Solver(BaseSolver):
         )
 
     def get_result(self):
-        params = np.concatenate([[self.intercept_], self.coef_], axis=0)
+        params = np.concatenate((self.coef_, [self.intercept_]))
         return params


### PR DESCRIPTION
This brings the following modification/enhancement

- add ``fit_intercept`` parameter
- compute ``lambda_max`` and pass in ``reg * lambda_max``
- use convention ``[*coef_, intercept]`` when pass in solution / computing objective


-----------
[link to benchmark](https://badr-moufad.github.io/share-benchmarks/quantile_regression/benchmark_quantile_regression_benchopt_run_2022-12-08_11h15m08.html)